### PR TITLE
Rename modifiers to grammemes

### DIFF
--- a/liblexeme.iml
+++ b/liblexeme.iml
@@ -31,6 +31,8 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="com.google.guava:guava:15.0" level="project" />
+    <orderEntry type="library" name="Maven: org.tendiwa:rocollections:0.3.0" level="project" />
+    <orderEntry type="library" name="Maven: org.tendiwa:collections-utils:1.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:15.0" level="project" />

--- a/src/main/java/org/tendiwa/lexeme/BasicGrammaticalMeaning.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicGrammaticalMeaning.java
@@ -36,7 +36,7 @@ final class BasicGrammaticalMeaning
         final List<TerminalNode> grammemeNodes = grammemesCtx.GRAMMEME();
         final ImmutableSet.Builder<Grammeme> builder = ImmutableSet.builder();
         for (TerminalNode node : grammemeNodes) {
-            builder.add(language.stringToModifier(node.getText()));
+            builder.add(language.grammemeByName(node.getText()));
         }
         return builder.build();
     }

--- a/src/main/java/org/tendiwa/lexeme/BasicWordBundleEntry.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicWordBundleEntry.java
@@ -55,7 +55,7 @@ final class BasicWordBundleEntry implements WordBundleEntry {
             .GRAMMEME()
             .stream()
             .map(TerminalNode::getText)
-            .map(this.language::stringToModifier)
+            .map(this.language::grammemeByName)
             .collect(Collectors.toImmutableSet());
     }
 }

--- a/src/main/java/org/tendiwa/lexeme/Language.java
+++ b/src/main/java/org/tendiwa/lexeme/Language.java
@@ -11,21 +11,23 @@ public interface Language {
     boolean validateLanguage(URL url);
 
     /**
-     * Implementation translate a String instance to a Modifier instance.
+     * Get a grammeme by its name.
+     * <p/>
      * This method in introduced to get the base implementation of Language
-     * acquainted with concrete implementation's Modifiers enum. So, in most
+     * acquainted with concrete implementation's Grammemes enum. So, in most
      * cases, the body of this method will simply be:
      * <pre>
-     *     Modifiers.valueOf(modifier);
+     *     Grammemes.valueOf(name);
      * </pre>
-     * Where {@code Modifiers} is an inner enum in your concrete implementation.
-     * @param modifier Name of enum instance. It is perfectly fine to name
-     * instances in your localized language (like {@code Modifiers.Муж}), and
-     * thus it is fine to pass a localized string as this parameter.
-     * @return A modifier enum instance whose
-     * {@code enumInstance.valueOf().equals(modifier)}
+     * Where {@code Grammemes} is an inner enum in your concrete implementation.
+     * @param name Name of enum instance. It is perfectly fine to name
+     * instances in your localized language (like {@code Grammemes.Муж} in
+     * Russian), and thus it is fine to pass a localized string as this
+     * parameter.
+     * @return A Grammemes enum instance whose
+     *  {@code enumInstance.valueOf().equals(name)}
      */
-    Grammeme stringToModifier(String modifier);
+    Grammeme grammemeByName(String name);
 
     String missingWord();
 

--- a/src/main/java/org/tendiwa/lexeme/LexemeTemplate.java
+++ b/src/main/java/org/tendiwa/lexeme/LexemeTemplate.java
@@ -18,17 +18,14 @@ private int wordStartIndex;
 private int wordEndIndex;
 
 /**
- * @param paramNumber
- * 	In the first bracket pair of a LexemeTemplate there is a localizationId; {@paramNumber} index of that localizationId
- * 	in MarkedUpText's header.
- * @param grammemes
- * 	Modifiers from the second bracket pair, or an empty array if there wasn't one.
- * @param wordStartIndex
- * 	Index in {@link BasicMarkedUpText#rawMarkedUpText} String on which the LexemeTemplate template
- * 	starts.
- * @param wordEndIndex
- * 	Index in {@link BasicMarkedUpText#rawMarkedUpText} String on which the LexemeTemplate template
- * 	starts.
+ * @param paramNumber In the first bracket pair of a LexemeTemplate there is
+ * a localizationId; {@paramNumber} index of that localizationId in MarkedUpText's header.
+ * @param grammemes Grammemes from the second bracket pair, or an empty array
+ * if there wasn't one.
+ * @param wordStartIndex Index in {@link BasicMarkedUpText#rawMarkedUpText}
+ * String on which the LexemeTemplate template starts.
+ * @param wordEndIndex Index in {@link BasicMarkedUpText#rawMarkedUpText} String
+ * on which the LexemeTemplate template starts.
  * @param firstLetterCapital
  * @param agreeingParameterName
  */

--- a/src/main/java/org/tendiwa/lexeme/PlaceholderGrammaticalMeaning.java
+++ b/src/main/java/org/tendiwa/lexeme/PlaceholderGrammaticalMeaning.java
@@ -47,7 +47,7 @@ public final class PlaceholderGrammaticalMeaning
             );
         }
         for (String grammemeName : placeholder.explicitGrammemes()) {
-            builder.add(language.stringToModifier(grammemeName));
+            builder.add(language.grammemeByName(grammemeName));
         }
         return builder.build();
     }

--- a/src/main/java/org/tendiwa/lexeme/implementations/English.java
+++ b/src/main/java/org/tendiwa/lexeme/implementations/English.java
@@ -15,8 +15,8 @@ public class English extends AbstractLanguage {
 	}
 
 	@Override
-	public Grammeme stringToModifier(String modifier) {
-		return English.Modifiers.valueOf(modifier);
+	public Grammeme grammemeByName(String name) {
+		return Grammemes.valueOf(name);
 	}
 
 	@Override
@@ -24,7 +24,7 @@ public class English extends AbstractLanguage {
 		return "[parameter_missing]";
 	}
 
-	public enum Modifiers implements Grammeme {
+	public enum Grammemes implements Grammeme {
         /**
          * Gerund.
          */

--- a/src/main/java/org/tendiwa/lexeme/implementations/Russian.java
+++ b/src/main/java/org/tendiwa/lexeme/implementations/Russian.java
@@ -21,8 +21,8 @@ public class Russian extends LanguageWithFallback {
 	}
 
 	@Override
-	public Grammeme stringToModifier(String modifier) {
-		return Modifiers.valueOf(modifier);
+	public Grammeme grammemeByName(String name) {
+		return Grammemes.valueOf(name);
 	}
 
 	@Override
@@ -37,27 +37,27 @@ public class Russian extends LanguageWithFallback {
 			if (asInt % 10 >= 2 && asInt % 10 <= 4 && asInt % 100 > 20) {
 				// 2 медведя, но 12 медведей
 				if (
-					!lexemeTemplate.getGrammemes().contains(Russian.Modifiers.Р)
-						&& !lexemeTemplate.getGrammemes().contains(Russian.Modifiers.В)
-						&& !lexemeTemplate.getGrammemes().contains(Russian.Modifiers.Д)
-						&& !lexemeTemplate.getGrammemes().contains(Russian.Modifiers.Т)
-						&& !lexemeTemplate.getGrammemes().contains(Russian.Modifiers.П)
+					!lexemeTemplate.getGrammemes().contains(Grammemes.Р)
+						&& !lexemeTemplate.getGrammemes().contains(Grammemes.В)
+						&& !lexemeTemplate.getGrammemes().contains(Grammemes.Д)
+						&& !lexemeTemplate.getGrammemes().contains(Grammemes.Т)
+						&& !lexemeTemplate.getGrammemes().contains(Grammemes.П)
 					) {
-					return Lists.<Grammeme>newArrayList(Modifiers.Мн, Modifiers.Р, Modifiers.Числ2До4);
+					return Lists.<Grammeme>newArrayList(Grammemes.Мн, Grammemes.Р, Grammemes.Числ2До4);
 				} else {
 					return null;
 				}
 			} else if (asInt % 10 == 1) {
-				return Lists.<Grammeme>newArrayList(Modifiers.Ед);
+				return Lists.<Grammeme>newArrayList(Grammemes.Ед);
 			} else {
-				return Lists.<Grammeme>newArrayList(Modifiers.Мн, Modifiers.Р);
+				return Lists.<Grammeme>newArrayList(Grammemes.Мн, Grammemes.Р);
 			}
 		} else {
 			return null;
 		}
 	}
 
-	public enum Modifiers implements Grammeme {
+	public enum Grammemes implements Grammeme {
 		/**
 		 * Мужской род.
 		 * <p>Masculine gender.


### PR DESCRIPTION
Grammemes were incorrectly called "modifiers".

Fixed #13 