### PR TITLE
Remove responsibility to fill up templates with lexemes from MarkedUpText

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.tendiwa</groupId>
             <artifactId>collections-utils</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.trove4j</groupId>

--- a/src/main/java/org/tendiwa/lexeme/BasicMarkedUpText.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicMarkedUpText.java
@@ -1,39 +1,22 @@
 package org.tendiwa.lexeme;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.tendiwa.lexeme.antlr.TextBundleParser;
-import org.tendiwa.rocollections.ReadOnlyList;
-import org.tendiwa.rocollections.WrappingReadOnlyList;
 
 /**
+ * MarkedUpText parsed from a parse tree.
  * @author Georgy Vlasov (suseika@tendiwa.org)
  * @version $Id$
  * @since 0.1
  */
 class BasicMarkedUpText implements MarkedUpText {
-    private final Language language;
-    private final NativeSpeaker nativeSpeaker;
     private final TextBundleParser.TextContext ctx;
 
     /**
-     * Text from file containing a header and body in the following form:
-     * <pre>
-     * text_localization_id (param1, param2, param3) {
-     *     Text about [param1] and [param2][Plur] mentioning [param3][Gerund].
-     * }
-     * </pre>
-     * @param language Language of the text.
      * @param ctx Parse subtree containing markup.
      */
     BasicMarkedUpText(
-        Language language,
-        NativeSpeaker nativeSpeaker,
         TextBundleParser.TextContext ctx
     ) {
-        this.language = language;
-        this.nativeSpeaker = nativeSpeaker;
         this.ctx = ctx;
     }
 
@@ -43,29 +26,12 @@ class BasicMarkedUpText implements MarkedUpText {
     }
 
     @Override
-    public final String fillUp(Localizable... denotations) {
-        final FillingUpText text = new FillingUpText(
-            this.language,
-            new ActualArguments(
-                new ParsedDeclaredArguments(this.ctx),
-                this.lexemes(denotations)
-            )
-        );
-        ParseTreeWalker.DEFAULT.walk(
-            text,
-            this.ctx
-        );
-        return text.toString();
+    public DeclaredArguments declaredArguments() {
+        return new ParsedDeclaredArguments(this.ctx);
     }
 
-    private ReadOnlyList<Lexeme> lexemes(Localizable[] conceptions) {
-        List<Lexeme> lexemes = new ArrayList<>(conceptions.length);
-        for (Localizable denotation : conceptions) {
-            lexemes.add(
-                this.nativeSpeaker.wordFor(denotation)
-            );
-        }
-        return new WrappingReadOnlyList<>(lexemes);
+    @Override
+    public final TextBundleParser.TemplateContext body() {
+        return this.ctx.template();
     }
-
 }

--- a/src/main/java/org/tendiwa/lexeme/LexemeTemplate.java
+++ b/src/main/java/org/tendiwa/lexeme/LexemeTemplate.java
@@ -3,7 +3,7 @@ package org.tendiwa.lexeme;
 import java.util.List;
 
 /**
- * Represents a part of text entry in .texts file in a form of [role][mo di fi ers] where this template is going to be
+ * Represents a part of text entry in .texts file in a form of [role][mo di fi ers] where this body is going to be
  * substituted by a particular lexeme.
  * @author Georgy Vlasov (suseika@tendiwa.org)
  * @version $Id$
@@ -23,9 +23,9 @@ private int wordEndIndex;
  * @param grammemes Grammemes from the second bracket pair, or an empty array
  * if there wasn't one.
  * @param wordStartIndex Index in {@link BasicMarkedUpText#rawMarkedUpText}
- * String on which the LexemeTemplate template starts.
+ * String on which the LexemeTemplate body starts.
  * @param wordEndIndex Index in {@link BasicMarkedUpText#rawMarkedUpText} String
- * on which the LexemeTemplate template starts.
+ * on which the LexemeTemplate body starts.
  * @param firstLetterCapital
  * @param agreeingParameterName
  */

--- a/src/main/java/org/tendiwa/lexeme/MarkedUpText.java
+++ b/src/main/java/org/tendiwa/lexeme/MarkedUpText.java
@@ -1,7 +1,20 @@
 package org.tendiwa.lexeme;
 
+import org.tendiwa.lexeme.antlr.TextBundleParser;
+
 /**
  * Text with unfilled placeholders.
+ * A single marked up text. It consists of three parts:
+ * <ol>
+ *     <li>Localization id;</li>
+ *     <li>List of argument names;</li>
+ *     <li>Template body.</li>
+ * </ol>
+ * <pre>
+ * localization_id (param1, param2, param3) {
+ *     Text about [param1] and [param2][Plur] mentioning [param3][Gerund].
+ * }
+ * </pre>
  * @author Georgy Vlasov (suseika@tendiwa.org)
  * @version $Id$
  */
@@ -12,11 +25,14 @@ public interface MarkedUpText {
      * @return Id of this text.
      */
     String id();
+
     /**
-     * Fill up placehodlers with lexemes.
-     * @param denotations Localizables whose lexemes to use to fill up the
-     * marked up text.
-     * @return Plain localized text.
+     * @return Names of arguments from the header of this marked up text.
      */
-    String fillUp(Localizable... denotations);
+    DeclaredArguments declaredArguments();
+
+    /**
+     * @return Parse tree of the body body (everything within brackets).
+     */
+    TextBundleParser.TemplateContext body();
 }

--- a/src/main/java/org/tendiwa/lexeme/TextBundleFromStream.java
+++ b/src/main/java/org/tendiwa/lexeme/TextBundleFromStream.java
@@ -39,20 +39,18 @@ public class TextBundleFromStream implements TextBundle {
         try {
             final List<TextBundleParser.TextContext> texts =
                 new TextBundleParser(
-                new CommonTokenStream(
-                    new TextBundleLexer(
-                        new ANTLRInputStream(
-                            this.stream
+                    new CommonTokenStream(
+                        new TextBundleLexer(
+                            new ANTLRInputStream(
+                                this.stream
+                            )
                         )
                     )
-                )
-            ).text_bundle().text();
+                ).text_bundle().text();
             final List<MarkedUpText> answer = new ArrayList<>(texts.size());
             for (TextBundleParser.TextContext ctx : texts) {
                 answer.add(
                     new BasicMarkedUpText(
-                        this.language,
-                        this.nativeSpeaker,
                         ctx
                     )
                 );

--- a/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
+++ b/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
@@ -2,7 +2,6 @@ package org.tendiwa.lexeme;
 
 import junit.framework.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public final class BasicMarkedUpTextTest {
 
@@ -14,8 +13,6 @@ public final class BasicMarkedUpTextTest {
         Assert.assertEquals(
             "action.act",
             new BasicMarkedUpText(
-                Mockito.mock(Language.class),
-                Mockito.mock(NativeSpeaker.class),
                 new TextBundleParserFactory()
                     .create(
                         "action.act(actor, seer) {",


### PR DESCRIPTION
Instead of filling up a template, MarkedUpText now can return a parse tree of its template body so something else can produce an actual text from that.

Fixes #21