### PR TITLE
Define and implement Grammar interface

### DIFF
--- a/src/main/java/org/tendiwa/lexeme/AbstractLanguage.java
+++ b/src/main/java/org/tendiwa/lexeme/AbstractLanguage.java
@@ -11,23 +11,33 @@ public abstract class AbstractLanguage implements Language {
 
     private final String localizedName;
 
-
     private final String localeName;
+    private final Class<? extends Grammeme> grammemesClass;
 
     /**
-     * @param localizedName Name of the language in that language, for example "Русский" for Russian.
+     * @param localizedName Name of the language in that language, for example
+     *  "Русский" for Russian.
      */
-    protected AbstractLanguage(String localizedName, String localeName) {
+    protected AbstractLanguage(
+        String localizedName,
+        String localeName,
+        Class<? extends Grammeme> grammemesClass
+    ) {
         this.localizedName = localizedName;
         this.localeName = localeName;
+        this.grammemesClass = grammemesClass;
     }
-
 
     @Override
     public final boolean validateLanguage(URL url) {
         return url.getPath().matches(
             "(.*\\.)" + this.getLocaleName() + "(\\..*)"
         );
+    }
+
+    @Override
+    public Grammar grammar() {
+        return new EnumBasedGrammar(this.grammemesClass);
     }
 
 

--- a/src/main/java/org/tendiwa/lexeme/BasicGrammaticalMeaning.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicGrammaticalMeaning.java
@@ -17,26 +17,26 @@ final class BasicGrammaticalMeaning
     implements GrammaticalMeaning {
 
     /**
-     * @param language Target language
+     * @param grammar Grammar of the target language
      * @param grammemesCtx Parse tree
      */
     public BasicGrammaticalMeaning(
-        Language language,
+        Grammar grammar,
         WordBundleParser.GrammemesContext grammemesCtx
     ) {
         super(
-            BasicGrammaticalMeaning.grammemes(language, grammemesCtx)
+            BasicGrammaticalMeaning.grammemes(grammar, grammemesCtx)
         );
     }
 
     private static ImmutableSet<Grammeme> grammemes(
-        Language language,
+        Grammar grammar,
         WordBundleParser.GrammemesContext grammemesCtx
     ) {
         final List<TerminalNode> grammemeNodes = grammemesCtx.GRAMMEME();
         final ImmutableSet.Builder<Grammeme> builder = ImmutableSet.builder();
         for (TerminalNode node : grammemeNodes) {
-            builder.add(language.grammemeByName(node.getText()));
+            builder.add(grammar.grammemeByName(node.getText()));
         }
         return builder.build();
     }

--- a/src/main/java/org/tendiwa/lexeme/BasicLexemeEntry.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicLexemeEntry.java
@@ -13,11 +13,11 @@ final class BasicLexemeEntry implements LexemeEntry {
     private final String wordForm;
 
     BasicLexemeEntry(
-        final Language language,
+        final Grammar grammar,
         final WordBundleParser.EntryContext entryCtx
     ) {
         this.grammemes = new BasicGrammaticalMeaning(
-            language,
+            grammar,
             entryCtx.grammemes()
         );
         this.wordForm = this.extractWordForm(entryCtx);

--- a/src/main/java/org/tendiwa/lexeme/BasicWordBundleEntry.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicWordBundleEntry.java
@@ -13,11 +13,14 @@ import org.tenidwa.collections.utils.Collectors;
  * @since 0.1
  */
 final class BasicWordBundleEntry implements WordBundleEntry {
-    private final Language language;
+    private final Grammar grammar;
     private final WordBundleParser.WordContext wordCtx;
 
-    public BasicWordBundleEntry(Language language, WordBundleParser.WordContext wordCtx) {
-        this.language = language;
+    public BasicWordBundleEntry(
+        Grammar grammar,
+        WordBundleParser.WordContext wordCtx
+    ) {
+        this.grammar = grammar;
         this.wordCtx = wordCtx;
     }
 
@@ -41,7 +44,7 @@ final class BasicWordBundleEntry implements WordBundleEntry {
             .stream()
             .map(
                 entryCtx -> new BasicLexemeEntry(
-                    this.language,
+                    this.grammar,
                     entryCtx
                 )
             )
@@ -55,7 +58,7 @@ final class BasicWordBundleEntry implements WordBundleEntry {
             .GRAMMEME()
             .stream()
             .map(TerminalNode::getText)
-            .map(this.language::grammemeByName)
+            .map(this.grammar::grammemeByName)
             .collect(Collectors.toImmutableSet());
     }
 }

--- a/src/main/java/org/tendiwa/lexeme/EnumBasedGrammar.java
+++ b/src/main/java/org/tendiwa/lexeme/EnumBasedGrammar.java
@@ -1,0 +1,40 @@
+package org.tendiwa.lexeme;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class EnumBasedGrammar implements Grammar {
+
+    private final Class<? extends Grammeme> grammemes;
+
+    public EnumBasedGrammar(Class<? extends Grammeme> grammemes) {
+        if (!grammemes.isEnum()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "%s: Grammemes class must be an enum",
+                    grammemes.getCanonicalName()
+                )
+            );
+        }
+        this.grammemes = grammemes;
+    }
+
+    @Override
+    public Grammeme grammemeByName(String name) {
+        try {
+            return (Grammeme) this.grammemes
+                .getMethod("valueOf", String.class)
+                .invoke(null, name);
+        } catch (
+            NoSuchMethodException
+                | InvocationTargetException
+                | IllegalAccessException e
+            ) {
+            throw new AssertionError("Reflective static method call failed");
+        }
+    }
+}

--- a/src/main/java/org/tendiwa/lexeme/FillingUpText.java
+++ b/src/main/java/org/tendiwa/lexeme/FillingUpText.java
@@ -11,15 +11,15 @@ import org.tendiwa.lexeme.antlr.TextBundleParserBaseListener;
  * @since 0.1
  */
 class FillingUpText extends TextBundleParserBaseListener {
-    private final Language language;
+    private final Grammar grammar;
     private final ActualArguments arguments;
     private final StringBuilder builder;
 
     FillingUpText(
-        Language language,
+        Grammar grammar,
         ActualArguments arguments
     ) {
-        this.language = language;
+        this.grammar = grammar;
         this.arguments = arguments;
         this.builder = new StringBuilder();
     }
@@ -38,7 +38,7 @@ class FillingUpText extends TextBundleParserBaseListener {
                 .form(
                     new PlaceholderGrammaticalMeaning(
                         placeholder,
-                        this.language,
+                        this.grammar,
                         this.arguments
                     )
                 )

--- a/src/main/java/org/tendiwa/lexeme/Grammar.java
+++ b/src/main/java/org/tendiwa/lexeme/Grammar.java
@@ -1,0 +1,16 @@
+package org.tendiwa.lexeme;
+
+/**
+ * Grammar of a natural language. Knows grammemes by their name.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public interface Grammar {
+    /**
+     * @param name Name of a grammeme
+     * @return Grammeme by its name.
+     * @throws IllegalArgumentException If there is no Grammeme with such name.
+     */
+    Grammeme grammemeByName(String name);
+}

--- a/src/main/java/org/tendiwa/lexeme/InputStreamWordBundle.java
+++ b/src/main/java/org/tendiwa/lexeme/InputStreamWordBundle.java
@@ -19,13 +19,16 @@ public final class InputStreamWordBundle implements WordBundle {
     private final ImmutableList<WordBundleEntry> words;
 
     InputStreamWordBundle(
-        Language language,
+        Grammar grammar,
         InputStream in
     ) {
-        this.words = this.parseWords(language, in);
+        this.words = this.parseWords(grammar, in);
     }
 
-    private ImmutableList<WordBundleEntry> parseWords(Language language, InputStream in) {
+    private ImmutableList<WordBundleEntry> parseWords(
+        Grammar grammar,
+        InputStream in
+    ) {
         try {
             return
                 new WordBundleParser(
@@ -40,7 +43,7 @@ public final class InputStreamWordBundle implements WordBundle {
                     .word_bundle()
                     .word()
                     .stream()
-                    .map(word -> new BasicWordBundleEntry(language, word))
+                    .map(word -> new BasicWordBundleEntry(grammar, word))
                     .collect(Collectors.toImmutableList());
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/tendiwa/lexeme/Language.java
+++ b/src/main/java/org/tendiwa/lexeme/Language.java
@@ -10,29 +10,11 @@ import java.net.URL;
 public interface Language {
     boolean validateLanguage(URL url);
 
-    /**
-     * Get a grammeme by its name.
-     * <p/>
-     * This method in introduced to get the base implementation of Language
-     * acquainted with concrete implementation's Grammemes enum. So, in most
-     * cases, the body of this method will simply be:
-     * <pre>
-     *     Grammemes.valueOf(name);
-     * </pre>
-     * Where {@code Grammemes} is an inner enum in your concrete implementation.
-     * @param name Name of enum instance. It is perfectly fine to name
-     * instances in your localized language (like {@code Grammemes.Муж} in
-     * Russian), and thus it is fine to pass a localized string as this
-     * parameter.
-     * @return A Grammemes enum instance whose
-     *  {@code enumInstance.valueOf().equals(name)}
-     */
-    Grammeme grammemeByName(String name);
-
     String missingWord();
-
 
     String getLocaleName();
 
     String getLocalizedName();
+
+    Grammar grammar();
 }

--- a/src/main/java/org/tendiwa/lexeme/LanguageWithFallback.java
+++ b/src/main/java/org/tendiwa/lexeme/LanguageWithFallback.java
@@ -14,9 +14,10 @@ public abstract class LanguageWithFallback extends AbstractLanguage {
     protected LanguageWithFallback(
         String localizedName,
         String localeName,
+        Class<? extends Grammeme> grammemesClass,
         Language fallbackLanguage
     ) {
-        super(localizedName, localeName);
+        super(localizedName, localeName, grammemesClass);
         this.fallbackLanguage = fallbackLanguage;
     }
 }

--- a/src/main/java/org/tendiwa/lexeme/PlaceholderGrammaticalMeaning.java
+++ b/src/main/java/org/tendiwa/lexeme/PlaceholderGrammaticalMeaning.java
@@ -14,19 +14,19 @@ public final class PlaceholderGrammaticalMeaning
     implements GrammaticalMeaning {
 
     /**
-     * @param placeholder Placeholder in the marked up text.
-     * @param language Language of the marked up text.
-     * @param arguments Arguments in the marked up text.
+     * @param placeholder Placeholder in the marked up text
+     * @param grammar Grammar of the target language
+     * @param arguments Arguments in the marked up text
      */
     public PlaceholderGrammaticalMeaning(
         Placeholder placeholder,
-        Language language,
+        Grammar grammar,
         ActualArguments arguments
     ) {
         super(
              PlaceholderGrammaticalMeaning.grammemes(
                 placeholder,
-                language,
+                grammar,
                 arguments
             )
         );
@@ -34,7 +34,7 @@ public final class PlaceholderGrammaticalMeaning
 
     private static ImmutableSet<Grammeme> grammemes(
         Placeholder placeholder,
-        Language language,
+        Grammar grammar,
         ActualArguments arguments
     ) {
         final ImmutableSet.Builder<Grammeme> builder = ImmutableSet.builder();
@@ -47,7 +47,7 @@ public final class PlaceholderGrammaticalMeaning
             );
         }
         for (String grammemeName : placeholder.explicitGrammemes()) {
-            builder.add(language.grammemeByName(grammemeName));
+            builder.add(grammar.grammemeByName(grammemeName));
         }
         return builder.build();
     }

--- a/src/main/java/org/tendiwa/lexeme/implementations/English.java
+++ b/src/main/java/org/tendiwa/lexeme/implementations/English.java
@@ -11,12 +11,7 @@ import org.tendiwa.lexeme.Grammeme;
  */
 public class English extends AbstractLanguage {
 	public English() {
-		super("English", "en_US");
-	}
-
-	@Override
-	public Grammeme grammemeByName(String name) {
-		return Grammemes.valueOf(name);
+		super("English", "en_US", English.Grammemes.class);
 	}
 
 	@Override
@@ -29,14 +24,17 @@ public class English extends AbstractLanguage {
          * Gerund.
          */
 		Ger,
+
         /**
          * Singular.
          */
 		Sing,
+
         /**
          * Plural.
          */
 		Plur,
+
         /**
          * Third person.
          */

--- a/src/main/java/org/tendiwa/lexeme/implementations/Russian.java
+++ b/src/main/java/org/tendiwa/lexeme/implementations/Russian.java
@@ -12,18 +12,14 @@ import org.tendiwa.lexeme.LanguageWithFallback;
 public class Russian extends LanguageWithFallback {
 
 	public Russian() {
-		super("Русский", "ru_RU", new English());
-	}
-
-	@Override
-	public Grammeme grammemeByName(String name) {
-		return Grammemes.valueOf(name);
+		super("Русский", "ru_RU", Russian.Grammemes.class, new English());
 	}
 
 	@Override
 	public String missingWord() {
 		return "[параметр пропущен]";
 	}
+
 
 	public enum Grammemes implements Grammeme {
 		/**

--- a/src/test/java/org/tendiwa/lexeme/EnumBasedGrammarTest.java
+++ b/src/test/java/org/tendiwa/lexeme/EnumBasedGrammarTest.java
@@ -1,0 +1,28 @@
+package org.tendiwa.lexeme;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+/**
+ * @since 0.1
+ */
+public final class EnumBasedGrammarTest {
+    @Test
+    public void findsGrammemeByName() {
+        MatcherAssert.assertThat(
+            new EnumBasedGrammar(KobaianGrammemes.class)
+                .grammemeByName("Default"),
+            CoreMatchers.equalTo(KobaianGrammemes.Default)
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsNonEnumGrammemes() {
+        new EnumBasedGrammar(new Grammeme() {}.getClass());
+    }
+
+    private enum KobaianGrammemes implements Grammeme {
+        Default
+    }
+}

--- a/src/test/java/org/tendiwa/lexeme/InputStreamWordBundleTest.java
+++ b/src/test/java/org/tendiwa/lexeme/InputStreamWordBundleTest.java
@@ -13,7 +13,7 @@ public final class InputStreamWordBundleTest {
     @Test
     public void findsWords() {
         final ImmutableList<WordBundleEntry> words = new InputStreamWordBundle(
-            new Russian(),
+            new Russian().grammar(),
             IOUtils.toInputStream(
                 Joiner.on('\n').join(
                     "\"dragon\" [Муж] {",


### PR DESCRIPTION
`Language` was doing too much. 

`Grammar` interface was made to map `Grammeme` names to `Grammeme`s. This interface is now used where it is appropriate instead of `Language`.

Fixes #27