### PR TITLE
Encapsulate ANTLR parse tree inside walkable MarkedUpTextBody

### DIFF
--- a/src/main/java/org/tendiwa/lexeme/BasicMarkedUpText.java
+++ b/src/main/java/org/tendiwa/lexeme/BasicMarkedUpText.java
@@ -31,7 +31,7 @@ class BasicMarkedUpText implements MarkedUpText {
     }
 
     @Override
-    public final TextBundleParser.TemplateContext body() {
-        return this.ctx.template();
+    public final MarkedUpTextBody body() {
+        return new ParsedMarkedUpTextBody(this.ctx.template());
     }
 }

--- a/src/main/java/org/tendiwa/lexeme/BodyWalker.java
+++ b/src/main/java/org/tendiwa/lexeme/BodyWalker.java
@@ -1,0 +1,39 @@
+package org.tendiwa.lexeme;
+
+/**
+ * Walks over a template, encountering plaintext parts and placeholder parts.
+ * <p/>
+ * For example, this marked up text has two plaintext parts and one
+ * placeholder part:
+ * <pre>
+ * story (dude) {
+ *     Once upon a time, some [dude][Plur] were born.
+ * }
+ * </pre>
+ * Those parts are:
+ * <ol>
+ *     <li><pre>Once upon a time, some </pre> — plain text;</li>
+ *     <li><pre>[dude][Plur]</pre> — placeholder;</li>
+ *     <li><pre> were born.</pre> — plain text;</li>
+ * </ol>
+ * <p/>
+ * A BodyWalker walking over the body of such {@link MarkedUpText} would
+ * encounter these parts in this very order, and call corresponding methods
+ * for each encounter.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public interface BodyWalker {
+    /**
+     * Called when a placeholder is encountered.
+     * @param placeholder Encountered placeholder.
+     */
+    void enterPlaceholder(Placeholder placeholder);
+
+    /**
+     * Called when plain text part is encountered.
+     * @param plainText Encountered plain text part.
+     */
+    void enterPlaintext(String plainText);
+}

--- a/src/main/java/org/tendiwa/lexeme/IdOnlyPlaceholder.java
+++ b/src/main/java/org/tendiwa/lexeme/IdOnlyPlaceholder.java
@@ -1,0 +1,40 @@
+package org.tendiwa.lexeme;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import org.tendiwa.lexeme.antlr.TextBundleParser;
+
+/**
+ * Placeholder that has only its identifier and doesn't have any additional
+ * grammatical meaning specified.
+ * <p/>
+ * Example: {@code [Attacker]} or {@code [defender]}.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+final class IdOnlyPlaceholder implements Placeholder {
+
+    private final TextBundleParser.No_category_placeholderContext ctx;
+
+    public IdOnlyPlaceholder(
+        TextBundleParser.No_category_placeholderContext noCategoryPlaceholderCtx
+    ) {
+        this.ctx = noCategoryPlaceholderCtx;
+    }
+
+    @Override
+    public String id() {
+        return this.ctx.CAPITALIZABLE_ID().getText();
+    }
+
+    @Override
+    public Optional<String> agreementId() {
+        return Optional.absent();
+    }
+
+    @Override
+    public ImmutableList<String> explicitGrammemes() {
+        return ImmutableList.of();
+    }
+}

--- a/src/main/java/org/tendiwa/lexeme/MarkedUpText.java
+++ b/src/main/java/org/tendiwa/lexeme/MarkedUpText.java
@@ -1,7 +1,5 @@
 package org.tendiwa.lexeme;
 
-import org.tendiwa.lexeme.antlr.TextBundleParser;
-
 /**
  * Text with unfilled placeholders.
  * A single marked up text. It consists of three parts:
@@ -27,12 +25,12 @@ public interface MarkedUpText {
     String id();
 
     /**
-     * @return Names of arguments from the header of this marked up text.
+     * @return Names of arguments from the header of this text.
      */
     DeclaredArguments declaredArguments();
 
     /**
-     * @return Parse tree of the body body (everything within brackets).
+     * @return Body of this text.
      */
-    TextBundleParser.TemplateContext body();
+    MarkedUpTextBody body();
 }

--- a/src/main/java/org/tendiwa/lexeme/MarkedUpTextBody.java
+++ b/src/main/java/org/tendiwa/lexeme/MarkedUpTextBody.java
@@ -1,0 +1,12 @@
+package org.tendiwa.lexeme;
+
+/**
+ * Body of a {@link MarkedUpText}. Body consists of plain text with
+ * placeholders.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+public interface MarkedUpTextBody {
+    void walk(BodyWalker walker);
+}

--- a/src/main/java/org/tendiwa/lexeme/ParsedMarkedUpTextBody.java
+++ b/src/main/java/org/tendiwa/lexeme/ParsedMarkedUpTextBody.java
@@ -1,0 +1,68 @@
+package org.tendiwa.lexeme;
+
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.tendiwa.lexeme.antlr.TextBundleParser;
+import org.tendiwa.lexeme.antlr.TextBundleParserBaseListener;
+
+/**
+ * MarkedUpTextBody coming from an ANTLR parse tree.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.1
+ */
+final class ParsedMarkedUpTextBody implements MarkedUpTextBody {
+    private final TextBundleParser.TemplateContext ctx;
+
+    /**
+     * ANTLR parse tree for a body of a marked up text.
+     * @param ctx Body context.
+     */
+    ParsedMarkedUpTextBody(TextBundleParser.TemplateContext ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void walk(BodyWalker walker) {
+        ParseTreeWalker.DEFAULT.walk(
+            new ParseTreeListener(walker),
+            this.ctx
+        );
+    }
+
+    /**
+     * Walks over ANTLR parse tree, creates proper objects from its plaintext
+     * findings and passes what it created to {@link BodyWalker}
+     */
+    private static final class ParseTreeListener
+        extends TextBundleParserBaseListener  {
+
+        private final BodyWalker walker;
+
+        ParseTreeListener(BodyWalker walker) {
+            this.walker = walker;
+        }
+
+        @Override
+        public final void enterPlaceholder(
+            TextBundleParser.PlaceholderContext ctx
+        ) {
+            this.walker.enterPlaceholder(
+                new TwoPartPlaceholder(ctx)
+            );
+        }
+
+        @Override
+        public final void enterRaw_text(TextBundleParser.Raw_textContext ctx) {
+            this.walker.enterPlaintext(ctx.getText());
+        }
+
+        @Override
+        public final void enterNo_category_placeholder(
+            TextBundleParser.No_category_placeholderContext ctx
+        ) {
+            this.walker.enterPlaceholder(
+                new IdOnlyPlaceholder(ctx)
+            );
+        }
+    }
+}

--- a/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
+++ b/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
@@ -1,8 +1,16 @@
 package org.tendiwa.lexeme;
 
+import com.google.common.base.Joiner;
+import java.util.ArrayList;
+import java.util.Collection;
 import junit.framework.Assert;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+/**
+ * @since 0.1
+ */
 public final class BasicMarkedUpTextTest {
 
     /**
@@ -23,5 +31,48 @@ public final class BasicMarkedUpTextTest {
             )
                 .id()
         );
+    }
+
+    @Test
+    public void hasWalkableBody() {
+        final UnwrappingWalker walker = new UnwrappingWalker();
+        new BasicMarkedUpText(
+            new TextBundleParserFactory()
+                .create(
+                    "story.short(dude, dudette) {",
+                    "  [Dude] and [dudette] once ate a taco.",
+                    "}"
+                )
+                .text()
+        )
+            .body()
+            .walk(walker);
+        MatcherAssert.assertThat(
+            walker.joined(),
+            CoreMatchers.equalTo("Dude and dudette once ate a taco.")
+        );
+    }
+
+    /**
+     * A BodyWalker that joins placeholder IDs and plaintext together into a
+     * single string.
+     */
+    private static final class UnwrappingWalker implements BodyWalker {
+
+        final Collection<String> parts = new ArrayList<>();
+
+        @Override
+        public void enterPlaceholder(Placeholder placeholder) {
+            parts.add(placeholder.id());
+        }
+
+        @Override
+        public void enterPlaintext(String plainText) {
+            parts.add(plainText);
+        }
+
+        public String joined() {
+            return Joiner.on("").join(parts);
+        }
     }
 }


### PR DESCRIPTION
ANTLR parse tree structure was being returned from `MarkedUpText#body()`, and `MarkedUpText`'s clients had to implement their own algorightm for obtaining useful information from that parse tree. 

I hid this algorithm behind `MarkedUpTextBody` interface and created `BodyWalker` interface that walks that body just like an ANTLR `*BaseListener` walks a parse tree. But `BodyWalker` walks proper objects instead of `*BaseListener`'s nodes.

Fixes #32