### PR TITLE
Replace Guava's Optional with Java 8 Optional

### DIFF
--- a/src/main/java/org/tendiwa/lexeme/IdOnlyPlaceholder.java
+++ b/src/main/java/org/tendiwa/lexeme/IdOnlyPlaceholder.java
@@ -1,7 +1,7 @@
 package org.tendiwa.lexeme;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import org.tendiwa.lexeme.antlr.TextBundleParser;
 
 /**
@@ -30,7 +30,7 @@ final class IdOnlyPlaceholder implements Placeholder {
 
     @Override
     public Optional<String> agreementId() {
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/tendiwa/lexeme/Placeholder.java
+++ b/src/main/java/org/tendiwa/lexeme/Placeholder.java
@@ -1,7 +1,7 @@
 package org.tendiwa.lexeme;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 
 /**
  * Placeholder in place of a lexeme in a marked up text.

--- a/src/main/java/org/tendiwa/lexeme/TwoPartPlaceholder.java
+++ b/src/main/java/org/tendiwa/lexeme/TwoPartPlaceholder.java
@@ -1,8 +1,8 @@
 package org.tendiwa.lexeme;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Optional;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.tendiwa.lexeme.antlr.TextBundleParser;
 


### PR DESCRIPTION
Guava's `Optional` was left there since the project was for JDK 1.7. Now the project is using JDK 1.8, so Guava's `Optional` is no longer needed.

Fixes #35 