### PR TITLE
Simplify BodyWalker

### DIFF
--- a/src/main/java/org/tendiwa/lexeme/BodyWalker.java
+++ b/src/main/java/org/tendiwa/lexeme/BodyWalker.java
@@ -24,16 +24,12 @@ package org.tendiwa.lexeme;
  * @version $Id$
  * @since 0.1
  */
+@FunctionalInterface
 public interface BodyWalker {
     /**
      * Called when a placeholder is encountered.
      * @param placeholder Encountered placeholder.
+     * @return Text that {@code placehodler} is turned into.
      */
-    void enterPlaceholder(Placeholder placeholder);
-
-    /**
-     * Called when plain text part is encountered.
-     * @param plainText Encountered plain text part.
-     */
-    void enterPlaintext(String plainText);
+    String enterPlaceholder(Placeholder placeholder);
 }

--- a/src/main/java/org/tendiwa/lexeme/MarkedUpTextBody.java
+++ b/src/main/java/org/tendiwa/lexeme/MarkedUpTextBody.java
@@ -8,5 +8,12 @@ package org.tendiwa.lexeme;
  * @since 0.1
  */
 public interface MarkedUpTextBody {
-    void walk(BodyWalker walker);
+    /**
+     * Walks itself with {@code walker} applying
+     * {@link BodyWalker#enterPlaceholder(Placeholder)} to every placeholder to
+     * turn it into actual text.
+     * @param walker Body walker
+     * @return Text with placeholders filled up.
+     */
+    String walk(BodyWalker walker);
 }

--- a/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
+++ b/src/test/java/org/tendiwa/lexeme/BasicMarkedUpTextTest.java
@@ -1,8 +1,5 @@
 package org.tendiwa.lexeme;
 
-import com.google.common.base.Joiner;
-import java.util.ArrayList;
-import java.util.Collection;
 import junit.framework.Assert;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -35,44 +32,19 @@ public final class BasicMarkedUpTextTest {
 
     @Test
     public void hasWalkableBody() {
-        final UnwrappingWalker walker = new UnwrappingWalker();
-        new BasicMarkedUpText(
-            new TextBundleParserFactory()
-                .create(
-                    "story.short(dude, dudette) {",
-                    "  [Dude] and [dudette] once ate a taco.",
-                    "}"
-                )
-                .text()
-        )
-            .body()
-            .walk(walker);
         MatcherAssert.assertThat(
-            walker.joined(),
+            new BasicMarkedUpText(
+                new TextBundleParserFactory()
+                    .create(
+                        "story.short(dude, dudette) {",
+                        "  [Dude] and [dudette] once ate a taco.",
+                        "}"
+                    )
+                    .text()
+            )
+                .body()
+                .walk(Placeholder::id),
             CoreMatchers.equalTo("Dude and dudette once ate a taco.")
         );
-    }
-
-    /**
-     * A BodyWalker that joins placeholder IDs and plaintext together into a
-     * single string.
-     */
-    private static final class UnwrappingWalker implements BodyWalker {
-
-        final Collection<String> parts = new ArrayList<>();
-
-        @Override
-        public void enterPlaceholder(Placeholder placeholder) {
-            parts.add(placeholder.id());
-        }
-
-        @Override
-        public void enterPlaintext(String plainText) {
-            parts.add(plainText);
-        }
-
-        public String joined() {
-            return Joiner.on("").join(parts);
-        }
     }
 }


### PR DESCRIPTION
Responsibility to constrcut text by filling up placeholders was on `BodyWalker` or its clients. It would be always done the same way, so it is moved to `MarkedUpTextBody`.

Fixes #42 