### PR TITLE
#54 Make ParsedVocabulary implement Map

### DIFF
--- a/src/main/java/org/tendiwa/lexeme/ParsedVocabulary.java
+++ b/src/main/java/org/tendiwa/lexeme/ParsedVocabulary.java
@@ -1,8 +1,10 @@
 package org.tendiwa.lexeme;
 
+import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableMap;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import org.tenidwa.collections.utils.Collectors;
 
 /**
@@ -11,7 +13,8 @@ import org.tenidwa.collections.utils.Collectors;
  * @version $Id$
  * @since 0.1
  */
-public final class ParsedVocabulary {
+public final class ParsedVocabulary
+    extends ForwardingMap<String, Lexeme> implements Map<String, Lexeme> {
 
     private final List<InputStream> input;
     private final Grammar grammar;
@@ -23,9 +26,6 @@ public final class ParsedVocabulary {
         this.lexemes = this.constructLexemes();
     }
 
-    public ImmutableMap<String, Lexeme> lexemes() {
-        return this.lexemes;
-    }
 
     private ImmutableMap<String, Lexeme> constructLexemes() {
         return ImmutableMap.copyOf(
@@ -61,5 +61,10 @@ public final class ParsedVocabulary {
                 )
                 .collect(Collectors.toImmutableList())
         );
+    }
+
+    @Override
+    protected Map<String, Lexeme> delegate() {
+        return this.lexemes;
     }
 }

--- a/src/test/java/org/tendiwa/lexeme/ParsedVocabularyTest.java
+++ b/src/test/java/org/tendiwa/lexeme/ParsedVocabularyTest.java
@@ -33,19 +33,19 @@ public final class ParsedVocabularyTest {
                 )
             );
         MatcherAssert.assertThat(
-            bundle.lexemes().size(),
+            bundle.size(),
             CoreMatchers.equalTo(2)
         );
         MatcherAssert.assertThat(
-            bundle.lexemes().containsKey("dragon"),
+            bundle.containsKey("dragon"),
             CoreMatchers.equalTo(true)
         );
         MatcherAssert.assertThat(
-            bundle.lexemes().get("dragon").baseForm(),
+            bundle.get("dragon").baseForm(),
             CoreMatchers.equalTo("dragon")
         );
         MatcherAssert.assertThat(
-            bundle.lexemes().get("dragon").form(
+            bundle.get("dragon").form(
                 new BasicGrammaticalMeaning(
                     English.Grammemes.Plur
                 )


### PR DESCRIPTION
ParsedVocabulary doesn't do anything other than being a map from conception ids to lexemes. A way to construct that map is needed anyway, and it doesn't make sense as a public method of any object. That's why I decided that ParsedVocabulary should be a Map that constructs itself.