### PR TITLE
Use cobertura for test coverage

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -7,6 +7,10 @@ decrypt:
   secring.gpg: "repo/secring.gpg.asc"
 docker:
   image: "maven:3.2.5-jdk-8"
+merge:
+  script: |
+    mvn clean install -Pcobertura
+    mvn clean
 release:
   script: |
     mvn versions:set "-DnewVersion=${tag}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk:
-   - oraclejdk8
+  - oraclejdk8
 notifications:
-   email: false
+  email: false
+script:
+  - mvn clean install -Pcobertura

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <cobertura.branchRate>0</cobertura.branchRate>
+        <cobertura.lineRate>0</cobertura.lineRate>
+        <cobertura.packageBranchRate>0</cobertura.packageBranchRate>
+        <cobertura.packageLineRate>0</cobertura.packageLineRate>
+        <cobertura.totalBranchRate>0</cobertura.totalBranchRate>
+        <cobertura.totalLineRate>0</cobertura.totalLineRate>
     </properties>
     <groupId>org.tendiwa.lexeme</groupId>
     <artifactId>lexeme</artifactId>
@@ -36,7 +42,6 @@
                     </execution>
                 </executions>
                 <configuration>
-
                     <visitor>true</visitor>
                     <arguments>
                         <argument>-package</argument>
@@ -48,6 +53,86 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>cobertura</id>
+            <!--<dependencyManagement>-->
+                <!--<dependencies>-->
+                    <!--<dependency>-->
+                        <!--<groupId>xerces</groupId>-->
+                        <!--<artifactId>xercesImpl</artifactId>-->
+                        <!--<version>2.11.0</version>-->
+                    <!--</dependency>-->
+                <!--</dependencies>-->
+            <!--</dependencyManagement>-->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <configuration>
+                            <check>
+                                <haltOnFailure>true</haltOnFailure>
+                                <branchRate>${cobertura.branchRate}</branchRate>
+                                <lineRate>${cobertura.lineRate}</lineRate>
+                                <packageBranchRate>${cobertura.packageBranchRate}</packageBranchRate>
+                                <packageLineRate>${cobertura.packageLineRate}</packageLineRate>
+                                <totalBranchRate>${cobertura.totalBranchRate}</totalBranchRate>
+                                <totalLineRate>${cobertura.totalLineRate}</totalLineRate>
+                            </check>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>clean</goal>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cobertura-forcereport</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <version>2.7</version>
+                        <configuration>
+                            <instrumentation>
+                                <excludes>
+                                    <exclude>com/xockets/shims/InputShim$2.class</exclude>
+                                    <exclude>com/xockets/layer/appliance/Encode$1.class</exclude>
+                                </excludes>
+                            </instrumentation>
+                            <check>
+                                <haltOnFailure>false</haltOnFailure>
+                                <branchRate>${cobertura.branchRate}</branchRate>
+                                <lineRate>${cobertura.lineRate}</lineRate>
+                                <packageBranchRate>${cobertura.packageBranchRate}</packageBranchRate>
+                                <packageLineRate>${cobertura.packageLineRate}</packageLineRate>
+                                <totalBranchRate>${cobertura.totalBranchRate}</totalBranchRate>
+                                <totalLineRate>${cobertura.totalLineRate}</totalLineRate>
+                            </check>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>cobertura-report</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                    <goal>cobertura</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Created profiles `-Pcobertura"` and `-Pcobertura-forcereport`.

`-Pcobertura` will instrument classes and fail a build if coverage expectations are not met. It will not generate a report.
`-Pcovertura-forcereport` will generate a report and disable build failing due to lack of coverage. It is useful for a developer, not for continuous integration and releases.

Set up Travis CI and rultor to use code coverage.

Fixes #29 